### PR TITLE
🛟 Arrumador: Configure tooling with mise and GitHub Actions

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,75 @@
+name: Autorelease
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 6'
+
+jobs:
+  autorelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: lucasew-github
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2025.2.6
+
+      - name: Install dependencies
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update generated code"
+          title: "chore: update generated code"
+          body: "This PR updates generated code based on the latest changes."
+          branch: "chore/codegen-update"
+          base: "master"
+
+      - name: CI
+        run: mise run ci
+
+      - name: Build
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mise run build
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} --generate-notes
+
+      - name: Upload Artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} nixgram

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -37,13 +37,13 @@ jobs:
           version: 2025.2.6
           install: false
 
-      - name: Install dependencies
+      - name: Install
         run: mise run install
 
       - name: Codegen
         run: mise run codegen
 
-      - name: Create Pull Request
+      - name: PR if Difference
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,10 +56,6 @@ jobs:
       - name: CI
         run: mise run ci
 
-      - name: Build
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-        run: mise run build
-
       - name: Release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
@@ -67,9 +63,10 @@ jobs:
         run: |
           gh release create ${{ github.ref_name || github.run_id }} --generate-notes || true
 
-      - name: Upload Artifacts
+      - name: Artifacts
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mise run build
           gh release upload ${{ github.ref_name || github.run_id }} nixgram || true

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -45,7 +45,6 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update generated code"
@@ -58,19 +57,19 @@ jobs:
         run: mise run ci
 
       - name: Build
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: mise run build
 
       - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} --generate-notes
+          gh release create ${{ github.ref_name || github.run_id }} --generate-notes || true
 
       - name: Upload Artifacts
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref_name }} nixgram
+          gh release upload ${{ github.ref_name || github.run_id }} nixgram || true

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           version: 2025.2.6
+          install: false
 
       - name: Install dependencies
         run: mise run install

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,0 @@
-linters:
-  disable:
-    - errcheck
-    - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  disable:
+    - errcheck
+    - stylecheck

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 go = "1.23.0"
 python = "3.12.0"
-"ubi:lucasew/workspaced" = "0.1.5"
+"github:lucasew/workspaced" = "0.1.5"
 
 [tasks]
 "install" = { depends = ["install:*"] }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,17 @@
+[tools]
+go = "1.23.0"
+python = "3.12.0"
+"ubi:lucasew/workspaced" = "0.1.5"
+
+[tasks]
+"install" = { depends = ["install:*"] }
+"install:go" = "go mod download"
+"test" = { depends = ["test:*"] }
+"test:unit" = "go test ./..."
+"codegen" = { depends = ["codegen:*"] }
+"codegen:nix" = "python3 .github/update-nix-hashes.py"
+"codegen:tidy" = "go mod tidy"
+"lint" = "workspaced codebase lint"
+"fmt" = "workspaced codebase format"
+"ci" = { depends = ["lint", "test"] }
+"build" = "go build -o nixgram ."

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 go = "1.23.0"
 python = "3.12.0"
-"github:lucasew/workspaced" = "0.1.5"
+"ubi:lucasew/workspaced" = "0.1.5"
 
 [tasks]
 "install" = { depends = ["install:*"] }


### PR DESCRIPTION
This PR configures the repository's tooling to establish a robust foundation using `mise` and `workspaced`, as requested.

### Changes
1.  **Mise Configuration (`mise.toml`)**:
    -   Configured `go`, `python`, and `workspaced` (via `ubi`) as tools.
    -   Defined standard tasks:
        -   `install`: Downloads Go modules (`go mod download`).
        -   `test`: Runs unit tests (`go test ./...`).
        -   `codegen`: Updates Nix hashes (`python3 .github/update-nix-hashes.py`) and tidies Go modules (`go mod tidy`).
        -   `lint`: Runs `workspaced codebase lint`.
        -   `fmt`: Runs `workspaced codebase format`.
        -   `ci`: Runs `lint` and `test`.
        -   `build`: Builds the `nixgram` binary.

2.  **GitHub Actions (`.github/workflows/autorelease.yml`)**:
    -   Created a single workflow replacing `cachix.yml` and `update-deps.yml`.
    -   Flow:
        1.  Install tools via `mise`.
        2.  Run `mise run codegen`.
        3.  Create a PR if codegen resulted in changes.
        4.  Run `mise run ci`.
        5.  On tags: Build, Release, and Upload Artifacts.

3.  **Cleanup**:
    -   Removed `cachix.yml` and `update-deps.yml` to avoid duplicate workflows.

### Verification
-   Verified `mise run ci` locally.
-   Ensured strict adherence to wildcard dependencies for `install`, `test`, and `codegen`.
-   Verified no forbidden artifacts (like `mise` binary) are committed.

---
*PR created automatically by Jules for task [2807399801741544885](https://jules.google.com/task/2807399801741544885) started by @lucasew*