### PR TITLE
🛠️ Refactor: Centralize error reporting and extract global state

### DIFF
--- a/cmd/nixgram/main.go
+++ b/cmd/nixgram/main.go
@@ -7,36 +7,40 @@ import (
 	"strconv"
 
 	"github.com/lucasew/nixgram"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
-var token string
-var adm int
-var err error
+type Config struct {
+    Token string
+    Adm   int
+}
 
-func loadEnvironment() error {
-    token = os.Getenv("NIXGRAM_TOKEN")
+func loadEnvironment() (*Config, error) {
+    token := os.Getenv("NIXGRAM_TOKEN")
     if (token == "") {
-        return fmt.Errorf("Missing NIXGRAM_TOKEN")
+        return nil, fmt.Errorf("Missing NIXGRAM_TOKEN")
     }
     admStr := os.Getenv("NIXGRAM_ADM")
     if (admStr == "") {
-        return fmt.Errorf("Missing NIXGRAM_ADM")
+        return nil, fmt.Errorf("Missing NIXGRAM_ADM")
     }
-    adm, err = strconv.Atoi(admStr)
+    adm, err := strconv.Atoi(admStr)
     if (err != nil) {
-        return fmt.Errorf("NIXGRAM_ADM: %s is not a number", admStr)
+        return nil, fmt.Errorf("NIXGRAM_ADM: %s is not a number", admStr)
     }
-    return nil
+    return &Config{Token: token, Adm: adm}, nil
 }
 
 func main() {
-    err := loadEnvironment()
+    config, err := loadEnvironment()
     if err != nil {
-        panic(err)
+        errreporter.ReportError(err, "failed to load environment")
+        os.Exit(1)
     }
-    bot, err := nixgram.NewNixGram(token, adm)
+    bot, err := nixgram.NewNixGram(config.Token, config.Adm)
     if err != nil {
-        panic(err)
+        errreporter.ReportError(err, "failed to initialize bot")
+        os.Exit(1)
     }
     bot.Run(context.Background())
 }

--- a/nixgram.go
+++ b/nixgram.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
 type NixGram struct {
@@ -53,12 +54,13 @@ func (n *NixGram) handleMessage(ctx context.Context, u tgbotapi.Update) {
     }
     r, err := NewRunner(n, u.Message.Text, u.Message.From.ID)
     if err != nil {
+        errreporter.ReportError(err, "failed to create runner")
         return
     }
     go func() {
         err = r.Run(ctx)
         if (err != nil) {
-            log.Printf("ERRO: (%d) %s", u.Message.From.ID, err.Error())
+            errreporter.ReportError(err, "runner execution failed")
         }
     }()
 }

--- a/pkg/errreporter/reporter.go
+++ b/pkg/errreporter/reporter.go
@@ -1,0 +1,15 @@
+package errreporter
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// ReportError is the centralized error reporting function.
+// All code paths that handle unexpected errors MUST funnel through this function.
+func ReportError(err error, contextMsg string) {
+	if err == nil {
+		return
+	}
+	log.Printf("ERROR: %s: %v\nStack trace:\n%s", contextMsg, err, debug.Stack())
+}

--- a/runner.go
+++ b/runner.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
 type Runner struct {
@@ -68,17 +69,25 @@ func (r *Runner) Run(ctx context.Context) error {
     _, ok := r.getCommand()
     if !ok {
         err := fmt.Errorf("comando %s não encontrado", r.command)
-        r.sendMessage(err.Error())
+        if sendErr := r.sendMessage(err.Error()); sendErr != nil {
+            errreporter.ReportError(sendErr, "failed to send command not found message")
+        }
         return err
     }
     out := bytes.NewBuffer([]byte{})
-    r.sendMessage("Running...")
+    if sendErr := r.sendMessage("Running..."); sendErr != nil {
+        errreporter.ReportError(sendErr, "failed to send Running message")
+    }
     err := r.handleCommand(ctx, out)
-    if r.sendMessage(out.String()) != nil {
-        r.sendTextFile(out)
+    if sendErr := r.sendMessage(out.String()); sendErr != nil {
+        if fileErr := r.sendTextFile(out); fileErr != nil {
+            errreporter.ReportError(fileErr, "failed to send text file fallback")
+        }
     }
     if err != nil {
-        r.sendMessage(fmt.Sprintf("Error: %s", err))
+        if sendErr := r.sendMessage(fmt.Sprintf("Error: %s", err)); sendErr != nil {
+            errreporter.ReportError(sendErr, "failed to send error message")
+        }
         return err
     }
     return nil


### PR DESCRIPTION
### Assumptions
- The application currently panics or silently ignores unexpected errors. It was assumed that routing these to a central error reporter, logging them properly, and optionally shutting down cleanly when initialization fails is the correct approach.
- The `nixgram.go`, `runner.go`, and `cmd/nixgram/main.go` are the primary places where unhandled errors existed that needed migration.
- `pkg/errreporter` is a suitable domain package to group centralized error reporting.

### Alternatives Not Chosen
- **Sentry Integration:** Although global directives mention Sentry, since this application doesn't currently appear to have Sentry configured or imported, a simple `log.Printf` with `debug.Stack()` was chosen to avoid introducing new dependencies. This can be easily replaced later.
- **Using structured logging (e.g., slog):** While standard `log` is used, a more robust structured logger could be added if requested, but wasn't to keep the refactor focused and within the 520 line limit.

### How To Pivot
- If a different logging backend is desired, only `pkg/errreporter/reporter.go` needs to be updated. The call sites will remain unchanged.
- If the global config struct should be further separated into a config package, `loadEnvironment` and `Config` from `cmd/nixgram/main.go` can be easily relocated to `pkg/config`.

### Next Knobs
- **`pkg/errreporter/reporter.go`:** Change the internal logging mechanism (e.g., to Sentry or zero log).
- **`cmd/nixgram/main.go`:** Change the environment variable keys or add new configuration values.
- **`runner.go`:** Adjust how fallback errors (like failed text file sends) are reported.

---
*PR created automatically by Jules for task [3756410808517742118](https://jules.google.com/task/3756410808517742118) started by @lucasew*