### PR TITLE
🛠️ Refactor: Centralize error reporting and configure tooling

### DIFF
--- a/.jules/notes.md
+++ b/.jules/notes.md
@@ -1,0 +1,1 @@
+Mise configuration and error handling fixes

--- a/cmd/nixgram-hey/main.go
+++ b/cmd/nixgram-hey/main.go
@@ -3,16 +3,16 @@ package main
 import (
 	"fmt"
 	"os"
-    "strings"
+	"strings"
 )
 
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Printf("Hey!\n")
-        return
-    }
-    fmt.Printf("Hey %s!\n", os.Args[1])
+	if len(os.Args) < 2 {
+		fmt.Printf("Hey!\n")
+		return
+	}
+	fmt.Printf("Hey %s!\n", os.Args[1])
 
-    fmt.Println("\nInspect")
-    fmt.Printf("Args: [ %s ]", strings.Join(os.Args, ", "))
+	fmt.Println("\nInspect")
+	fmt.Printf("Args: [ %s ]", strings.Join(os.Args, ", "))
 }

--- a/cmd/nixgram/main.go
+++ b/cmd/nixgram/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/lucasew/nixgram"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
 var token string
@@ -14,29 +15,31 @@ var adm int
 var err error
 
 func loadEnvironment() error {
-    token = os.Getenv("NIXGRAM_TOKEN")
-    if (token == "") {
-        return fmt.Errorf("Missing NIXGRAM_TOKEN")
-    }
-    admStr := os.Getenv("NIXGRAM_ADM")
-    if (admStr == "") {
-        return fmt.Errorf("Missing NIXGRAM_ADM")
-    }
-    adm, err = strconv.Atoi(admStr)
-    if (err != nil) {
-        return fmt.Errorf("NIXGRAM_ADM: %s is not a number", admStr)
-    }
-    return nil
+	token = os.Getenv("NIXGRAM_TOKEN")
+	if token == "" {
+		return fmt.Errorf("Missing NIXGRAM_TOKEN")
+	}
+	admStr := os.Getenv("NIXGRAM_ADM")
+	if admStr == "" {
+		return fmt.Errorf("Missing NIXGRAM_ADM")
+	}
+	adm, err = strconv.Atoi(admStr)
+	if err != nil {
+		return fmt.Errorf("NIXGRAM_ADM: %s is not a number", admStr)
+	}
+	return nil
 }
 
 func main() {
-    err := loadEnvironment()
-    if err != nil {
-        panic(err)
-    }
-    bot, err := nixgram.NewNixGram(token, adm)
-    if err != nil {
-        panic(err)
-    }
-    bot.Run(context.Background())
+	err := loadEnvironment()
+	if err != nil {
+		errreporter.ReportError(err, map[string]interface{}{"context": "loadEnvironment"})
+		panic(err)
+	}
+	bot, err := nixgram.NewNixGram(token, adm)
+	if err != nil {
+		errreporter.ReportError(err, map[string]interface{}{"context": "nixgram.NewNixGram"})
+		panic(err)
+	}
+	bot.Run(context.Background())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucasew/nixgram
 
-go 1.15
+go 1.21
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.21.0"
+golangci-lint = "1.54.2"
+
+[tasks]
+install = { run = "go mod download" }
+test = { run = "go test ./..." }
+codegen = { run = "go generate ./..." }
+lint = { run = "golangci-lint run" }
+fmt = { run = "go fmt ./..." }

--- a/nixgram.go
+++ b/nixgram.go
@@ -5,60 +5,67 @@ import (
 	"log"
 
 	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
 type NixGram struct {
-    Bot *tgbotapi.BotAPI
-    updatesChan tgbotapi.UpdatesChannel
-    Adm int
+	Bot         *tgbotapi.BotAPI
+	updatesChan tgbotapi.UpdatesChannel
+	Adm         int
 }
 
 func NewNixGram(token string, adm int) (*NixGram, error) {
-    bot, err := tgbotapi.NewBotAPI(token)
-    if err != nil {
-        return nil, err
-    }
-    updatesChan, err := bot.GetUpdatesChan(tgbotapi.UpdateConfig{
-        Limit: 1,
-        Timeout: 10,
-    })
-    if err != nil {
-        return nil, err
-    }
-    return &NixGram{
-        Bot: bot,
-        Adm: adm,
-        updatesChan: updatesChan,
-    }, nil
+	bot, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		return nil, err
+	}
+	updatesChan, err := bot.GetUpdatesChan(tgbotapi.UpdateConfig{
+		Limit:   1,
+		Timeout: 10,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &NixGram{
+		Bot:         bot,
+		Adm:         adm,
+		updatesChan: updatesChan,
+	}, nil
 }
 
-func (n* NixGram) Run(ctx context.Context) {
-    for {
-        select {
-            case u := <- n.updatesChan:
-                n.handleMessage(ctx, u)
-            case <- ctx.Done():
-                return
-        }
-    }
+func (n *NixGram) Run(ctx context.Context) {
+	for {
+		select {
+		case u := <-n.updatesChan:
+			n.handleMessage(ctx, u)
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (n *NixGram) handleMessage(ctx context.Context, u tgbotapi.Update) {
-    if u.Message == nil {
-        return
-    }
-    if u.Message.From.ID != n.Adm {
-        log.Printf("WARN: usuário não autorizado tentou usar o bot: %s (%d): %s", u.Message.From.UserName, u.Message.From.ID, u.Message.Text)
-        return
-    }
-    r, err := NewRunner(n, u.Message.Text, u.Message.From.ID)
-    if err != nil {
-        return
-    }
-    go func() {
-        err = r.Run(ctx)
-        if (err != nil) {
-            log.Printf("ERRO: (%d) %s", u.Message.From.ID, err.Error())
-        }
-    }()
+	if u.Message == nil {
+		return
+	}
+	if u.Message.From.ID != n.Adm {
+		log.Printf("WARN: usuário não autorizado tentou usar o bot: %s (%d): %s", u.Message.From.UserName, u.Message.From.ID, u.Message.Text)
+		return
+	}
+	r, err := NewRunner(n, u.Message.Text, u.Message.From.ID)
+	if err != nil {
+		errreporter.ReportError(err, map[string]interface{}{
+			"sender":  u.Message.From.ID,
+			"message": u.Message.Text,
+		})
+		return
+	}
+	go func() {
+		err = r.Run(ctx)
+		if err != nil {
+			errreporter.ReportError(err, map[string]interface{}{
+				"sender": u.Message.From.ID,
+			})
+		}
+	}()
 }

--- a/pkg/errreporter/reporter.go
+++ b/pkg/errreporter/reporter.go
@@ -1,0 +1,14 @@
+package errreporter
+
+import (
+	"log"
+)
+
+// ReportError centralizes error reporting for the application.
+// All code paths that handle unexpected errors MUST funnel through this function.
+func ReportError(err error, context map[string]interface{}) {
+	if err == nil {
+		return
+	}
+	log.Printf("ERROR: %v | Context: %v", err, context)
+}

--- a/pkg/errreporter/reporter_test.go
+++ b/pkg/errreporter/reporter_test.go
@@ -1,0 +1,34 @@
+package errreporter
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestReportError(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	// Test nil error
+	ReportError(nil, nil)
+	if buf.Len() > 0 {
+		t.Errorf("Expected nothing logged for nil error, got: %s", buf.String())
+	}
+
+	// Test non-nil error
+	err := errors.New("test error")
+	context := map[string]interface{}{"key": "value"}
+	ReportError(err, context)
+
+	output := buf.String()
+	if !strings.Contains(output, "ERROR: test error") {
+		t.Errorf("Expected output to contain 'ERROR: test error', got: %s", output)
+	}
+	if !strings.Contains(output, "Context: map[key:value]") {
+		t.Errorf("Expected output to contain 'Context: map[key:value]', got: %s", output)
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -4,88 +4,103 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-    "io"
+	"io"
 	"log"
 	"os/exec"
 	"strings"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/lucasew/nixgram/pkg/errreporter"
 )
 
 type Runner struct {
-    bot *NixGram
-    command string
-    args []string
-    sender int
+	bot     *NixGram
+	command string
+	args    []string
+	sender  int
 }
 
 func NewRunner(bot *NixGram, message string, sender int) (*Runner, error) {
-    params, err := PocSplitter(message)
-    return &Runner{
-        bot: bot,
-        command: params[0],
-        args: params[1:],
-        sender: sender,
-    }, err
+	params, err := PocSplitter(message)
+	return &Runner{
+		bot:     bot,
+		command: params[0],
+		args:    params[1:],
+		sender:  sender,
+	}, err
 }
 
 func (r *Runner) getCommand() (string, bool) {
-    cmdname := fmt.Sprintf("nixgram-%s", r.command)
-    fullCmd, err := exec.LookPath(cmdname)
-    if err != nil {
-        return "", false
-    }
-    return fullCmd, true
+	cmdname := fmt.Sprintf("nixgram-%s", r.command)
+	fullCmd, err := exec.LookPath(cmdname)
+	if err != nil {
+		return "", false
+	}
+	return fullCmd, true
 }
 
 func (r *Runner) sendMessage(msg string) error {
-    _, err := r.bot.Bot.Send(tgbotapi.NewMessage(int64(r.sender), msg))
-    return err
+	_, err := r.bot.Bot.Send(tgbotapi.NewMessage(int64(r.sender), msg))
+	return err
 }
 
 func (r *Runner) sendTextFile(b *bytes.Buffer) error {
-    _, err := r.bot.Bot.Send(tgbotapi.NewDocumentUpload(int64(r.sender), tgbotapi.FileReader{
-        Name: "out.txt",
-        Reader: b,
-        Size: int64(b.Len()),
-    }))
-    return err
+	_, err := r.bot.Bot.Send(tgbotapi.NewDocumentUpload(int64(r.sender), tgbotapi.FileReader{
+		Name:   "out.txt",
+		Reader: b,
+		Size:   int64(b.Len()),
+	}))
+	return err
 }
 
 func (r *Runner) handleCommand(ctx context.Context, b io.Writer) error {
-    cmdPath, ok := r.getCommand()
-    if !ok {
-        return fmt.Errorf("comando %s não encontrado", r.command)
-    }
-    cmd := exec.CommandContext(ctx, cmdPath, r.args...)
-    cmd.Stdout = b
-    cmd.Stderr = b
-    return cmd.Run()
+	cmdPath, ok := r.getCommand()
+	if !ok {
+		return fmt.Errorf("comando %s não encontrado", r.command)
+	}
+	cmd := exec.CommandContext(ctx, cmdPath, r.args...)
+	cmd.Stdout = b
+	cmd.Stderr = b
+	return cmd.Run()
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-    log.Printf("Command %d: %s [ %s ]", r.sender, r.command, strings.Join(r.args, ", "))
-    _, ok := r.getCommand()
-    if !ok {
-        err := fmt.Errorf("comando %s não encontrado", r.command)
-        r.sendMessage(err.Error())
-        return err
-    }
-    out := bytes.NewBuffer([]byte{})
-    r.sendMessage("Running...")
-    err := r.handleCommand(ctx, out)
-    if r.sendMessage(out.String()) != nil {
-        r.sendTextFile(out)
-    }
-    if err != nil {
-        r.sendMessage(fmt.Sprintf("Error: %s", err))
-        return err
-    }
-    return nil
+	log.Printf("Command %d: %s [ %s ]", r.sender, r.command, strings.Join(r.args, ", "))
+	_, ok := r.getCommand()
+	if !ok {
+		err := fmt.Errorf("comando %s não encontrado", r.command)
+		if sendErr := r.sendMessage(err.Error()); sendErr != nil {
+			errreporter.ReportError(sendErr, map[string]interface{}{"context": "sendMessage", "sender": r.sender})
+		}
+		errreporter.ReportError(err, map[string]interface{}{"command": r.command, "sender": r.sender})
+		return err
+	}
+	out := bytes.NewBuffer([]byte{})
+	if sendErr := r.sendMessage("Running..."); sendErr != nil {
+		errreporter.ReportError(sendErr, map[string]interface{}{"context": "sendMessage", "sender": r.sender})
+	}
+	err := r.handleCommand(ctx, out)
+
+	sendMsgErr := r.sendMessage(out.String())
+	if sendMsgErr != nil {
+		errreporter.ReportError(sendMsgErr, map[string]interface{}{"context": "sendMessage", "sender": r.sender})
+		sendFileErr := r.sendTextFile(out)
+		if sendFileErr != nil {
+			errreporter.ReportError(sendFileErr, map[string]interface{}{"context": "sendTextFile", "sender": r.sender})
+		}
+	}
+	if err != nil {
+		if sendErr := r.sendMessage(fmt.Sprintf("Error: %s", err)); sendErr != nil {
+			errreporter.ReportError(sendErr, map[string]interface{}{"context": "sendMessage", "sender": r.sender})
+		}
+		errreporter.ReportError(err, map[string]interface{}{"command": r.command, "args": r.args, "sender": r.sender})
+		return err
+	}
+	return nil
 }
 
-//TODO: Write a better splitter
+// TODO: Write a better splitter
 func PocSplitter(text string) ([]string, error) {
-    trimmed := strings.Trim(text, " /")
-    return strings.Split(trimmed, " "), nil
+	trimmed := strings.Trim(text, " /")
+	return strings.Split(trimmed, " "), nil
 }


### PR DESCRIPTION
This PR addresses the retroactive violations by implementing a centralized error-reporting function and correctly configuring the project tooling using `mise` as required by the global instructions.

### Assumptions
- I assumed that Go 1.21 is an acceptable version for this project, aligning the pinned `mise` tool version with the `go.mod` declaration.
- I assumed that errors should be logged with context using the standard library `log` package inside the `errreporter` package, allowing it to be easily extended with Sentry or other error tracking solutions in the future.

### Alternatives Not Chosen
- Continuing to use scattered `log.Printf` and `fmt.Errorf` calls without a central funnel. This was rejected as it violates the centralized error reporting directive.
- Using wildcard dependencies in `mise.toml` tasks. This was rejected because it caused 'task not found' syntax errors during task execution.

### How To Pivot
- If the `log` package is insufficient and a specific error tracking backend (e.g., Sentry) is preferred, update the `pkg/errreporter/reporter.go` implementation to initialize and use the specific backend client without changing the call sites across the application.
- If a different Go version is required, update `go.mod` and the `mise.toml` tool configuration.

### Next Knobs
- **`pkg/errreporter/reporter.go`**: Update this file to integrate with external error tracking systems (e.g., Sentry).
- **`mise.toml`**: Add or modify tasks, or update tool versions as needed.
- **`runner.go`**: Further refine error context details sent to `errreporter.ReportError` for more granular debugging.

---
*PR created automatically by Jules for task [16264601111314795184](https://jules.google.com/task/16264601111314795184) started by @lucasew*