### PR TITLE
📝 Docs: Document core bot orchestration and execution runner

### DIFF
--- a/nixgram.go
+++ b/nixgram.go
@@ -7,12 +7,17 @@ import (
 	"github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
+// NixGram represents the Telegram bot state and configuration.
+// It enforces a single-administrator security model where only the
+// user with the specified Adm ID can interact with the bot.
 type NixGram struct {
     Bot *tgbotapi.BotAPI
     updatesChan tgbotapi.UpdatesChannel
     Adm int
 }
 
+// NewNixGram initializes a new Telegram bot instance and its update channel.
+// The bot is configured to only process messages from the provided adm ID.
 func NewNixGram(token string, adm int) (*NixGram, error) {
     bot, err := tgbotapi.NewBotAPI(token)
     if err != nil {
@@ -32,6 +37,9 @@ func NewNixGram(token string, adm int) (*NixGram, error) {
     }, nil
 }
 
+// Run starts the main polling loop for Telegram updates.
+// It blocks until the context is canceled, spawning a new runner
+// for each authorized message.
 func (n* NixGram) Run(ctx context.Context) {
     for {
         select {

--- a/package.nix
+++ b/package.nix
@@ -8,7 +8,7 @@ buildGoModule {
 
   src = ./.;
 
-  vendorHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+  vendorHash = "sha256-QoVryPstnfdvc390pgAeLF04AXNzR2BEXLXY2isTK+s=";
 
   meta = with lib; {
     description = "A smol software that can interface with commands using telegram";

--- a/package.nix
+++ b/package.nix
@@ -8,7 +8,7 @@ buildGoModule {
 
   src = ./.;
 
-  vendorHash = "sha256-QoVryPstnfdvc390pgAeLF04AXNzR2BEXLXY2isTK+s=";
+  vendorHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
 
   meta = with lib; {
     description = "A smol software that can interface with commands using telegram";

--- a/runner.go
+++ b/runner.go
@@ -12,6 +12,8 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
+// Runner holds the execution state for a single user command.
+// It tracks the parsed command, arguments, and the ID of the requesting user.
 type Runner struct {
     bot *NixGram
     command string
@@ -19,6 +21,8 @@ type Runner struct {
     sender int
 }
 
+// NewRunner parses a Telegram text message into an executable command
+// and arguments, associating them with a specific user session.
 func NewRunner(bot *NixGram, message string, sender int) (*Runner, error) {
     params, err := PocSplitter(message)
     return &Runner{
@@ -63,6 +67,9 @@ func (r *Runner) handleCommand(ctx context.Context, b io.Writer) error {
     return cmd.Run()
 }
 
+// Run executes the command in the foreground.
+// Commands are dynamically prefixed with "nixgram-" and looked up in $PATH.
+// Depending on output size, the result is sent as a Telegram message or attached as a file.
 func (r *Runner) Run(ctx context.Context) error {
     log.Printf("Command %d: %s [ %s ]", r.sender, r.command, strings.Join(r.args, ", "))
     _, ok := r.getCommand()
@@ -84,7 +91,10 @@ func (r *Runner) Run(ctx context.Context) error {
     return nil
 }
 
-//TODO: Write a better splitter
+// PocSplitter tokenizes a text command string into a command and slice of arguments.
+// It removes trailing/leading slashes and spaces before splitting by spaces.
+//
+// TODO: Write a better splitter
 func PocSplitter(text string) ([]string, error) {
     trimmed := strings.Trim(text, " /")
     return strings.Split(trimmed, " "), nil


### PR DESCRIPTION
## Assumptions
- The primary entrypoint and security model logic resides in `nixgram.go`.
- The `runner.go` file handles the execution of commands prefixed with `nixgram-`.
- Standard Go `//` comments are required over the system prompt's `/** ... */` suggestion.

## Alternatives Not Chosen
- Documenting the `cmd/nixgram/main.go` entrypoint (scope kept cohesive to the core `nixgram` package API).

## How To Pivot
- If the `nixgram-` prefix description is inaccurate, modify the `Run` docstring in `runner.go`.

## Next Knobs
- Explore adding docstrings to `cmd/nixgram` or `cmd/nixgram-hey`.
- Improve the `PocSplitter` function as mentioned in the TODO comment.

---
*PR created automatically by Jules for task [506539091371384104](https://jules.google.com/task/506539091371384104) started by @lucasew*